### PR TITLE
Change README instructions for production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Gulp x React x Webpack x BrowserSync Boilerplate
 ## Folder Structure
 - Edit files in lib/*
 - Compiled assets are sent to public/assets
-- To build for production run `gulp`
+- To build for production run `npm build`


### PR DESCRIPTION
Change `gulp` command to `npm build` to be more consistent.
